### PR TITLE
Allow a stateful serial object

### DIFF
--- a/firmware/embeddedcsvnode/readme.md
+++ b/firmware/embeddedcsvnode/readme.md
@@ -129,7 +129,6 @@ struct CustomClock
 // Now the define the custom type
 using CustomCsvNode = csvnode::SerialCsvNode<CustomClock, CustomSerial>;
 ```
-Take care that the Serial-Port must be stateless!
 
 # Memory and Customization
 

--- a/firmware/embeddedcsvnode/src/CsvNodeProfile.h
+++ b/firmware/embeddedcsvnode/src/CsvNodeProfile.h
@@ -26,18 +26,21 @@ namespace csvnode
 #else
         constexpr char SEP[2] = ",";
 #endif
-
-        // This function must either throw an exception or interrupt execution of the program
-        template<typename Serial>
-        static inline void throwCsvNodeEx(etl::string_view msg)
+        class SerialPort
         {
-            Serial port;
-            port.write(msg.data(), msg.length());
+        public:
+            virtual void write(const etl::string_view msg) = 0;
+        };
+
+        static inline void throwCsvNodeEx(SerialPort& port, const etl::string_view msg)
+        {
+            port.write(msg);
 
 #ifdef CSVNODE_THROW_EXCEPTION
-        throw std::runtime_error(msg.data());
+            throw std::runtime_error(msg.data());
 #endif
-            while(true);
+            while (true)
+                ;
         }
     } // namespace details
 } // namespace csvnode

--- a/firmware/embeddedcsvnode/src/details/Registry.h
+++ b/firmware/embeddedcsvnode/src/details/Registry.h
@@ -8,7 +8,7 @@ namespace csvnode
     namespace details
     {
 
-        template <typename Serial, size_t NUM_CHANNELS>
+        template <size_t NUM_CHANNELS>
         class Registry
         {
             // Make the Iterator a Friend so that it can access the array
@@ -17,7 +17,7 @@ namespace csvnode
 
         public:
             using ChannelArray = etl::array<Channel, NUM_CHANNELS>;
-            Registry() : m_idx(0){};
+            Registry(details::SerialPort& serial_port) : m_idx(0), m_serial_port(serial_port) {};
             Registry(const Registry &) = delete;
             const Registry &operator=(const Registry &) = delete;
 
@@ -25,7 +25,7 @@ namespace csvnode
             {
                 if (idx >= NUM_CHANNELS)
                 {
-                    details::throwCsvNodeEx<Serial>("Out of range.");
+                    details::throwCsvNodeEx(m_serial_port, "Out of range.");
                 }
 
                 return m_channels[idx];
@@ -36,12 +36,12 @@ namespace csvnode
                 Channel new_channel(name);
                 if (m_idx > (NUM_CHANNELS - 1))
                 {
-                    details::throwCsvNodeEx<Serial>("Out of channels. Increase NUM_CHANNELS.");
+                    details::throwCsvNodeEx(m_serial_port, "Out of channels. Increase NUM_CHANNELS.");
                 }
 
                 if (exists(new_channel.getName()) != nullptr)
                 {
-                    details::throwCsvNodeEx<Serial>("Channel already exists.");
+                    details::throwCsvNodeEx(m_serial_port, "Channel already exists.");
                 }
 
                 m_channels[m_idx] = etl::move(new_channel);
@@ -62,7 +62,7 @@ namespace csvnode
 
                 if (ch == nullptr)
                 {
-                    details::throwCsvNodeEx<Serial>("Channel does not exist.");
+                    details::throwCsvNodeEx(m_serial_port, "Channel does not exist.");
                 }
                 return *ch;
             }
@@ -101,6 +101,7 @@ namespace csvnode
 
             ChannelArray m_channels = {};
             size_t m_idx;
+            details::SerialPort& m_serial_port;
         };
 
         template <typename T>
@@ -132,19 +133,19 @@ namespace csvnode
             T &collection;
         };
 
-        template <typename Serial, size_t NUM_CHANNELS>
-        using RegistryIterator = RegistryIteratorType<Registry<Serial, NUM_CHANNELS>>;
+        template <size_t NUM_CHANNELS>
+        using RegistryIterator = RegistryIteratorType<Registry<NUM_CHANNELS>>;
 
-        template <typename Serial, size_t NUM_CHANNELS>
-        inline RegistryIterator<Serial, NUM_CHANNELS> begin(Registry<Serial, NUM_CHANNELS> &collection)
+        template <size_t NUM_CHANNELS>
+        inline RegistryIterator<NUM_CHANNELS> begin(Registry<NUM_CHANNELS> &collection)
         {
-            return RegistryIterator<Serial, NUM_CHANNELS>(collection, 0);
+            return RegistryIterator<NUM_CHANNELS>(collection, 0);
         }
 
-        template <typename Serial, size_t NUM_CHANNELS>
-        inline RegistryIterator<Serial, NUM_CHANNELS> end(Registry<Serial, NUM_CHANNELS> &collection)
+        template <size_t NUM_CHANNELS>
+        inline RegistryIterator<NUM_CHANNELS> end(Registry<NUM_CHANNELS> &collection)
         {
-            return RegistryIterator<Serial, NUM_CHANNELS>(collection, collection.getSize());
+            return RegistryIterator<NUM_CHANNELS>(collection, collection.getSize());
         }
     } // namespace details
 } // namespace csvnode


### PR DESCRIPTION
With this PR, the serial object inside the CSVNode can have states (e.g. cached bytes...). This is not needed for Arduino, but useful on other platforms. In Addition, the CSVNode offers a function to directly write to the underlying serial port (e.g. additional Debug-Messages not yet interpreted by OXYGEN or strings not yet defined by the protocol). 